### PR TITLE
Don't assume stringsAsFactors=FALSE is set.

### DIFF
--- a/R/methods-sampleYAMLMetrics.R
+++ b/R/methods-sampleYAMLMetrics.R
@@ -37,6 +37,7 @@ NULL
         any(grepl(x = x, pattern = "^[0-9\\.]+$"))
     }
     metrics %>%
+        mutate_if(is.factor, as.character) %>% 
         mutate_if(numericAsCharacter, as.numeric) %>%
         mutate_if(is.character, as.factor) %>%
         .prepareSampleMetadata()


### PR DESCRIPTION
This converts any factors that happened to get loaded to characters first before converting, which should handle whatever stringsAsFactors the user has set.