### PR TITLE
v0.9.9 DESCRIPTION fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,14 +30,10 @@ BugReports: https://github.com/steinbaugh/basejump/issues/
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: false
-Depends:
-    R (>= 3.4),
-    bioverbs (>= 0.1.6),
-    goalie (>= 0.2.8),
-    transformer (>= 0.1.4),
-    syntactic (>= 0.1.4),
-    brio (>= 0.1.5)
+Depends: R (>= 3.4)
 Imports:
+    bioverbs (>= 0.1.6), brio (>= 0.1.5), goalie (>= 0.2.8),
+        syntactic (>= 0.1.4), transformer (>= 0.1.4),
     AnnotationHub, Biobase, BiocGenerics, GenomeInfoDb, GenomicFeatures,
         GenomicRanges, IRanges, Matrix, Matrix.utils, RColorBrewer, S4Vectors,
         SingleCellExperiment, SummarizedExperiment, ensembldb,


### PR DESCRIPTION
Revert back to not attaching basejump sub-packages using `Depends:`.